### PR TITLE
Added unit test for the Datalog Mapper.

### DIFF
--- a/test/language/datalog/arity0.py
+++ b/test/language/datalog/arity0.py
@@ -1,0 +1,12 @@
+from languages.predicate import Predicate
+
+
+class Arity0(Predicate):
+
+    predicate_name = "a"
+
+    def __init__(self):
+        super(Arity0, self).__init__([])
+
+    def __str__(self):
+        return "a"

--- a/test/language/datalog/datalog_mapper_test.py
+++ b/test/language/datalog/datalog_mapper_test.py
@@ -1,0 +1,50 @@
+import unittest
+
+from languages.datalog.datalog_mapper import DatalogMapper
+from test.language.asp.cell import Cell
+from test.language.datalog.arity0 import Arity0
+
+
+class DatalogMapperTest(unittest.TestCase):
+
+    def runTest(self):
+
+        instance = DatalogMapper.get_instance()
+
+        try:
+            instance.register_class(Cell)
+
+            obj = instance.get_object("cell(2,4,6)")
+
+            self.assertTrue(isinstance(obj, Cell))
+
+            self.assertEqual(2, obj.get_row())
+
+            self.assertEqual(4, obj.get_column())
+
+            self.assertEqual('6', obj.get_value().value)
+
+            self.assertEqual("cell(2,4,6)", instance.get_string(obj))
+
+            instance.unregister_class(Cell)
+
+            noneObject = instance.get_object("cell(2,4,6)")
+
+            self.assertIsNone(noneObject)
+
+            instance.register_class(Arity0)
+
+            zeroArityObject = instance.get_object("a")
+
+            self.assertIsNotNone(zeroArityObject)
+
+            self.assertTrue(isinstance(zeroArityObject, Arity0))
+
+            self.assertEqual("a()", instance.get_string(zeroArityObject))
+
+        except Exception as e:
+            self.fail(str(e))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Since every language supported by EmbASP must have its own unit test class, it was necessary to add a test class for Datalog as well, to keep the implementation of the language in line with the other implementations. It's a simple and short class, almost identical to the ASP test class. A difference to note is the introduction of the _Arity0_ class, which was missing from the Python release.