### PR TITLE
Added test resources submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test-resources"]
+	path = test-resources
+	url = https://github.com/demacs-unical/EmbASP-test-resources

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test-resources"]
 	path = test-resources
-	url = https://github.com/demacs-unical/EmbASP-test-resources
+	url = https://github.com/DeMaCS-UNICAL/EmbASP-test-resources.git

--- a/test/specialization/clingo/clingo_desktop_service_test.py
+++ b/test/specialization/clingo/clingo_desktop_service_test.py
@@ -24,7 +24,7 @@ class ClingoDesktopServiceTest(unittest.TestCase):
 
     def getPath(self):
         OS = sys.platform
-        path = os.path.join("..", "..", "..", "..",
+        path = os.path.join("..", "..", "..",
                             "test-resources", "asp", "executables", "clingo")
         if OS.startswith("win32"):
             if sys.maxsize > 2**32:

--- a/test/specialization/dlv/dlv_desktop_service_test.py
+++ b/test/specialization/dlv/dlv_desktop_service_test.py
@@ -24,7 +24,7 @@ class DLVDesktopServiceTest(unittest.TestCase):
 
     def getPath(self):
         OS = sys.platform
-        path = os.path.join("..", "..", "..", "..",
+        path = os.path.join("..", "..", "..",
                             "test-resources", "asp", "executables", "dlv")
         if OS.startswith("win32"):
             path = os.path.join(path, "dlv.mingw.exe")

--- a/test/specialization/dlv2/dlv2_desktop_service_test.py
+++ b/test/specialization/dlv2/dlv2_desktop_service_test.py
@@ -13,7 +13,7 @@ import platform
 class DLV2DesktopServiceTest(unittest.TestCase):
 
     def getPath(self):
-        path = os.path.join("..", "..", "..", "..", "test-resources", "asp", "executables", "dlv2")
+        path = os.path.join("..", "..", "..", "test-resources", "asp", "executables", "dlv2")
 
         if sys.platform.startswith("win32"):
             if platform.machine().endswith('64'):

--- a/test/specialization/idlv/idlv_desktop_service_test.py
+++ b/test/specialization/idlv/idlv_desktop_service_test.py
@@ -12,7 +12,7 @@ from test.specialization.idlv.path import Path
 
 
 def getPath():
-    path = os.path.join("..", "..", "..", "..", "test-resources", "datalog", "executables", "idlv")
+    path = os.path.join("..", "..", "..", "test-resources", "datalog", "executables", "idlv")
 
     if sys.platform.startswith("win32"):
         if platform.machine().endswith('64'):


### PR DESCRIPTION
Since we want to move the test resources from the main repository to the repositories of the various languages (C#, Java, Python), we need to add the test-resources folder in the various repositories of the languages. This PR covers the Python implementation.